### PR TITLE
Chore/Bug: use typing_extenesions module for 3.7 backport of `Literal` type

### DIFF
--- a/not/filesystem.py
+++ b/not/filesystem.py
@@ -1,7 +1,8 @@
 """filesystem utilities for not"""
 from itertools import chain
 from pathlib import Path
-from typing import Dict, Iterable, Iterator, List, Literal, Union
+from typing_extensions import Literal
+from typing import Dict, Iterable, Iterator, List, Union
 
 from .constants import (
     DOT_NOTHING_DIRECTORY_NAME,

--- a/poetry.lock
+++ b/poetry.lock
@@ -510,6 +510,14 @@ doc = ["mkdocs", "mkdocs-material", "markdown-include"]
 test = ["shellingham", "pytest (>=4.4.0)", "pytest-cov", "coverage", "pytest-xdist", "pytest-sugar", "mypy", "black", "isort"]
 
 [[package]]
+category = "main"
+description = "Backported and Experimental Type Hints for Python 3.5+"
+name = "typing-extensions"
+optional = false
+python-versions = "*"
+version = "3.7.4.2"
+
+[[package]]
 category = "dev"
 description = "Measures number of Terminal column cells of wide-character codes"
 name = "wcwidth"
@@ -539,7 +547,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "0dcc8570603627b73154bd759f80df980092b8c4a59b619d9689b684a3686be3"
+content-hash = "6fcb2869f90886f3343f728c36c892dd9bf15ff40e28c77ea5fd237f8bcb8509"
 python-versions = "^3.7"
 
 [metadata.files]
@@ -805,6 +813,11 @@ typed-ast = [
 typer = [
     {file = "typer-0.1.1-py3-none-any.whl", hash = "sha256:e6fdb492c2f20d2d8123b8b2f4efa060770f92664aad8d36126f53dce501e9a8"},
     {file = "typer-0.1.1.tar.gz", hash = "sha256:180d746de86724f9f94e90fa95caa065b5af9b3b3c77fc9d4d4ca1b75adc0c01"},
+]
+typing-extensions = [
+    {file = "typing_extensions-3.7.4.2-py2-none-any.whl", hash = "sha256:f8d2bd89d25bc39dabe7d23df520442fa1d8969b82544370e03d88b5a591c392"},
+    {file = "typing_extensions-3.7.4.2-py3-none-any.whl", hash = "sha256:6e95524d8a547a91e08f404ae485bbb71962de46967e1b71a0cb89af24e761c5"},
+    {file = "typing_extensions-3.7.4.2.tar.gz", hash = "sha256:79ee589a3caca649a9bfd2a8de4709837400dfa00b6cc81962a1e6a1815969ae"},
 ]
 wcwidth = [
     {file = "wcwidth-0.1.9-py2.py3-none-any.whl", hash = "sha256:cafe2186b3c009a04067022ce1dcd79cb38d8d65ee4f4791b8888d6599d1bbe1"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ colorama = "^0.4.3"
 typer = "^0.1.0"
 pydantic = "^1.4"
 "ruamel.yaml" = "^0.16.10"
+typing-extensions = "^3.7.4"
 
 [tool.poetry.dev-dependencies]
 pylint = "^2.4.4"


### PR DESCRIPTION
- Literal is not in 3.7