### PR TITLE
Glot: open files in binary mode

### DIFF
--- a/nothing_cli/localization/__init__.py
+++ b/nothing_cli/localization/__init__.py
@@ -45,7 +45,7 @@ class _Polyglot(Dict[str, str]):
             / self.language_mappings[self.locale].filename
         )
 
-        with open(locale_file, "r") as file:
+        with open(locale_file, "rb") as file:
             contents: Dict[str, str] = load(file)
             super(_Polyglot, self).__init__(contents)
 


### PR DESCRIPTION
This lets json handle the decoding, instead of picking the system locale. This ~is not guaranteed, but hopefully~ fixes: https://github.com/ainsleymcgrath/nothing/issues/31